### PR TITLE
give option to put clickhouse db url for clickhouse creds

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,10 +17,11 @@ clickhouse_backup_general_backups_to_keep_remote_monthly: 12
 ###############################################
 # Clickhouse related clickhouse-backup settings
 ###############################################
-clickhouse_backup_clickhouse_username: default
-clickhouse_backup_clickhouse_password: ""
-clickhouse_backup_clickhouse_host: localhost
-clickhouse_backup_clickhouse_port: 9000
+clickhouse_backup_clickhouse_db_url: ""
+clickhouse_backup_clickhouse_username: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('username') | default('default') }}"
+clickhouse_backup_clickhouse_password: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('password') | default('') }}"
+clickhouse_backup_clickhouse_host: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('hostname') | default('localhost') }}"
+clickhouse_backup_clickhouse_port: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('port') | default('localhost') }}"
 clickhouse_backup_clickhouse_data_path: ""
 clickhouse_backup_clickhouse_skip_tables:
   - system.*

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ clickhouse_backup_clickhouse_db_url: ""
 clickhouse_backup_clickhouse_username: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('username') | default('default') }}"
 clickhouse_backup_clickhouse_password: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('password') | default('') }}"
 clickhouse_backup_clickhouse_host: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('hostname') | default('localhost') }}"
-clickhouse_backup_clickhouse_port: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('port') | default('localhost') }}"
+clickhouse_backup_clickhouse_port: "{{ clickhouse_backup_clickhouse_db_url | urlsplit('port') | default(9000) }}"
 clickhouse_backup_clickhouse_data_path: ""
 clickhouse_backup_clickhouse_skip_tables:
   - system.*


### PR DESCRIPTION
Hi @nl2go-robot @dirkaholic thank you for your awesome repo to wrap clickhouse-backup into ansible-galaxy. I use this and I got an idea to give option for user to use clickhouse db url instead of one by one defining username, pass, hostname, etc. would be love to contribute more. I'd love to PR again re option for `backups_to_keep_local` and `backups_to_keep_remote` as I saw you only let remote backup but in the end delete local one, lets talk at another PR about this. thanks